### PR TITLE
Add Full Dockerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:13-alpine
 
-EXPOSE 6003
-
-COPY target/libs /app/libs
-COPY models /app/models
-COPY target/opennlp-service-1.0.jar /app
 WORKDIR /app
 
-CMD ["java", "-jar", "opennlp-service-1.0.jar"]
+COPY . /app
+
+RUN apk add --no-cache maven wget \
+ && mkdir /app/models && cd /app/models && wget -i ../models.url \
+ && cd /app && mvn clean package \
+ && apk del maven wget \
+ && rm -rf /var/cache/apk/*
+
+EXPOSE 80
+
+CMD ["java", "-jar", "target/opennlp-service-1.0.jar"]

--- a/README.md
+++ b/README.md
@@ -65,13 +65,16 @@ $ docker build -t opennlp .
 
 #### Run:
 ```bash
-$ docker run --name opennlp --rm --memory 4G -p 80:80 -d opennlp
+$ docker run --name opennlp --rm -p 80:80 -d opennlp
 ```
 To specify the listening port:
 ```bash
 $ docker run -e OPENNLP_SERVICE_PORT=1234 -p 1234:1234 -d opennlp
 ```
-
+If you're using Docker for Mac, you may have to specify a memory limit.
+```bash
+$ docker run --memory 4G -p 80:80 -d opennlp
+```
 
 ## Licenses
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This java program provides RESTful API for [Apache OpenNLP](https://opennlp.apac
 ### Notes:
 - It is based on [Jersey](https://jersey.github.io/) and [Grizzly](https://javaee.github.io/grizzly/) frameworks. 
 
-- Default binding address is: 0.0.0.0:6003
+- Default binding address is: 0.0.0.0:80
 
 - The web service consumes POST requests with raw data (`text/plain`) payload.
 
@@ -39,14 +39,14 @@ $ java -jar target/opennlp-service-1.0.jar
 
 #### 5. Use:
 ```bash
-$ curl http://localhost:6003/ -d "Grammar is useless because there is nothing to say."
+$ curl http://localhost -d "Grammar is useless because there is nothing to say."
 ```
 
 ### Changing binding address
 
 You can change listening address and port by these two environment variables:
-- OPENNLP_SERVICE_HOST
-- OPENNLP_SERVICE_PORT
+- `OPENNLP_SERVICE_HOST`
+- `OPENNLP_SERVICE_PORT`
 
 &nbsp;
 
@@ -65,7 +65,7 @@ $ docker build -t opennlp .
 
 #### Run:
 ```bash
-$ docker run -p 6003:6003 -d opennlp
+$ docker run --name opennlp --rm --memory 4G -p 80:80 -d opennlp
 ```
 To specify the listening port:
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,18 @@
             <version>1.9.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+           <version>2.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/ir/behzadan/corenlp/Main.java
+++ b/src/main/java/ir/behzadan/corenlp/Main.java
@@ -10,7 +10,7 @@ import java.net.URI;
 
 public class Main {
     static final String DEFAULT_HOST = "0.0.0.0";
-    static final String DEFAULT_PORT = "6003";
+    static final String DEFAULT_PORT = "80";
     public static String BASE_URI;
 
     public static HttpServer startServer() {


### PR DESCRIPTION
I ran into a number of issues getting this application setup locally due to the environment specific setup (differences in locally installed Java versions). This pull request aims to complete containerization by producing an independent image build process.

First the Java runtime is updated.

Secondly the container's exposed port is changed to the standard http 80 - this can still be configured with ENV variables.

Lastly all build steps are included in the Dockerfile and the image size was minimized by purging build dependencies.

Also a brief note about memory configuration when running the container in Docker for Mac.

You can test the image in this fork by pulling the build from docker hub:

    docker run --name opennlp --rm -p 80:80 jpuck/opennlp-service:release-feature_dockerize

And again if you're running Docker for Mac, then add the `--memory 4G`